### PR TITLE
fix: Links do repo atualizados no package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "suap-api-wrapper",
-  "version": "0.1.0",
+  "name": "suapi",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/isaacmsl/suap-api-wrapper.git"
+    "url": "https://github.com/isaacmsl/suapi.git"
   },
   "bugs": {
-    "url": "https://github.com/isaacmsl/suap-api-wrapper/issues"
+    "url": "https://github.com/isaacmsl/suapi/issues"
   },
-  "homepage": "https://github.com/isaacmsl/suap-api-wrapper"
+  "homepage": "https://github.com/isaacmsl/suapi"
 }


### PR DESCRIPTION
Os links para o este repositório estavam desatualizados no `package.json` e `package-lock.json`.