### PR TITLE
feat: Dados pessoais no SuapiV2

### DIFF
--- a/__tests__/auth-v2.spec.ts
+++ b/__tests__/auth-v2.spec.ts
@@ -1,11 +1,11 @@
 require('dotenv').config()
 
 import { SuapiV2 } from '../src/index'
-import { expect, it } from '@jest/globals'
+import { expect } from '@jest/globals'
 
 const { MATRICULA, SENHA } = process.env
 
 test('deve retornar um token de autorização', async () => {
     const authToken = await SuapiV2.getAuthToken(String(MATRICULA), String(SENHA))
-    expect(authToken).toBeInstanceOf(String)
+    expect(authToken).toBeDefined()
 })

--- a/__tests__/dados-pessoais.spec.ts
+++ b/__tests__/dados-pessoais.spec.ts
@@ -1,0 +1,12 @@
+require('dotenv').config()
+
+import { SuapiV2 } from '../src/index'
+import { expect } from '@jest/globals'
+
+const { MATRICULA, SENHA } = process.env
+
+test('deve retornar os dados pessoais', async () => {
+    const authToken: string = await SuapiV2.getAuthToken(String(MATRICULA), String(SENHA))
+    const dadosPessoais = await SuapiV2.getDadosPessoais(authToken)
+    expect(dadosPessoais).toBeDefined()
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "suapi",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suapi",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Wrapper para acesso a API do SUAP versão 2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SuapiV2.ts
+++ b/src/SuapiV2.ts
@@ -1,7 +1,10 @@
 import axios from 'axios'
 
+import IDadosAlunoV2 from './models/IDadosAlunoV2'
+
 export class SuapiV2 {
     public static BASE_URL: string = 'https://suap.ifrn.edu.br/api/v2/'
+    public static RESOURCES_DADOS_PESSOAIS_URL: string = 'minhas-informacoes/meus-dados/'
 
     /**
      * 
@@ -10,7 +13,7 @@ export class SuapiV2 {
      * @param matricula 
      * @param senha 
      */
-    public static async getAuthToken(matricula: string, senha: string): Promise<String> {
+    public static async getAuthToken(matricula: string, senha: string): Promise<string> {
         try {
             const response = await axios({
                 method: 'POST',
@@ -23,9 +26,26 @@ export class SuapiV2 {
                 }
             })
 
-            return new String(response.data.token)
+            return `JWT ${response.data.token}`
         } catch (error) {
             throw error
         }   
+    }
+
+    public static async getDadosPessoais(authToken: string): Promise<IDadosAlunoV2> {
+        try {
+            const response = await axios({
+                baseURL: SuapiV2.BASE_URL,
+                url: SuapiV2.RESOURCES_DADOS_PESSOAIS_URL,
+                params: { format: 'json' },
+                headers: {
+                    Authorization: authToken
+                }
+            })
+
+            return response.data
+        } catch (error) {
+            throw error
+        }
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './SuapiV2'
+export * from './models/IDadosAlunoV2'

--- a/src/models/IDadosAlunoV2.ts
+++ b/src/models/IDadosAlunoV2.ts
@@ -1,0 +1,28 @@
+export default interface IDadosAlunoV2 {
+    id: string,
+    matricula: string,
+    nome_usual: string,
+    cpf: string,
+    rg: string,
+    filiacao: Array<string | null>,
+    data_nascimento: string,
+    naturalidade: string,
+    tipo_sanguineo: string,
+    email: string,
+    url_foto_75x100: string,
+    url_foto_150x200: string,
+    tipo_vinculo: string,
+    vinculo: {
+        matricula: string,
+        nome: string,
+        curso: string,
+        campus: string,
+        situacao: string,
+        cota_sistec: string,
+        cota_mec: string,
+        situacao_sistemica: string,
+        matricula_regular: Boolean,
+        linha_pesquisa: string | null,
+        curriculo_lattes: string | null
+    }
+}


### PR DESCRIPTION
Foi adicionado um novo método estático que, através do `authToken: string`, consulta o endpoint `minhas-informacoes/meus-dados` e retorna o dados pessoais do usuário. 

Também foi criado um teste unitário para certificar que o novo método age corretamente.

Por fim, foi criada uma interface chamada `IDadosAlunoV2` para tipificar a resposta do endpoint citado.