### PR TITLE
Adicionada função útil para a maiorias dos endpoints

### DIFF
--- a/__tests__/auth-v2.spec.ts
+++ b/__tests__/auth-v2.spec.ts
@@ -1,4 +1,6 @@
 require('dotenv').config()
+import Debug from 'debug'
+const debug = new Debug('spec:auth-v2')
 
 import { SuapiV2 } from '../src/index'
 import { expect } from '@jest/globals'
@@ -7,5 +9,6 @@ const { MATRICULA, SENHA } = process.env
 
 test('deve retornar um token de autorização', async () => {
     const authToken = await SuapiV2.getAuthToken(String(MATRICULA), String(SENHA))
+    debug(authToken)
     expect(authToken).toBeDefined()
 })

--- a/__tests__/dados-pessoais.spec.ts
+++ b/__tests__/dados-pessoais.spec.ts
@@ -1,4 +1,6 @@
 require('dotenv').config()
+import Debug from 'debug'
+const debug = new Debug('spec:dados-pessoais')
 
 import { SuapiV2 } from '../src/index'
 import { expect } from '@jest/globals'
@@ -7,6 +9,9 @@ const { MATRICULA, SENHA } = process.env
 
 test('deve retornar os dados pessoais', async () => {
     const authToken: string = await SuapiV2.getAuthToken(String(MATRICULA), String(SENHA))
+
     const dadosPessoais = await SuapiV2.getDadosPessoais(authToken)
+    debug(dadosPessoais)
+
     expect(dadosPessoais).toBeDefined()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "suapi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "homepage": "https://github.com/isaacmsl/suapi",
   "devDependencies": {
     "@types/jest": "^26.0.15",
+    "debug": "^4.2.0",
     "dotenv": "^8.2.0",
     "jest": "^26.6.1",
     "ts-jest": "^26.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suapi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Wrapper para acesso a API do SUAP versão 2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/SuapiV2.ts
+++ b/src/SuapiV2.ts
@@ -34,18 +34,25 @@ export class SuapiV2 {
 
     public static async getDadosPessoais(authToken: string): Promise<IDadosAlunoV2> {
         try {
-            const response = await axios({
-                baseURL: SuapiV2.BASE_URL,
-                url: SuapiV2.RESOURCES_DADOS_PESSOAIS_URL,
-                params: { format: 'json' },
-                headers: {
-                    Authorization: authToken
-                }
-            })
-
-            return response.data
+            return await SuapiV2.getByAuthorization(
+                SuapiV2.RESOURCES_DADOS_PESSOAIS_URL, 
+                authToken
+            )
         } catch (error) {
             throw error
         }
+    }
+
+    public static async getByAuthorization(url: string, authToken: string) {
+        const response = await axios({
+            baseURL: SuapiV2.BASE_URL,
+            url: url,
+            params: { format: 'json' },
+            headers: {
+                Authorization: authToken
+            }
+        })
+
+        return response.data
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,13 @@
     "compilerOptions": {
         "declaration": true,
         "strictNullChecks": true,
-        "target": "ES2020",
+        "target": "ES2019",
         "outDir": "dist",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,
         "lib": [
-            "es2015",
-            "dom"
+            "es2019"
         ],
         "rootDir": "src"
     },


### PR DESCRIPTION
## getByAuthorization

Foi adicionada a função `getByAuthorization` que deve ser usada na maiorias dos endpoints futuros;
Agora só é preciso retornar:
https://github.com/isaacmsl/suapi/blob/91def05809711d78a2f5809b56bf535b28152df4/src/SuapiV2.ts#L37-L40
E a função `getByAuthorization` faz todo o resto:
https://github.com/isaacmsl/suapi/blob/91def05809711d78a2f5809b56bf535b28152df4/src/SuapiV2.ts#L46-L58

## debug package

Agora é possível debugar os testes de spec do `Jest` utilizando o pacote `debug`, como em:
https://github.com/isaacmsl/suapi/blob/91def05809711d78a2f5809b56bf535b28152df4/__tests__/dados-pessoais.spec.ts#L10-L17

Para executar o testes e verificar o debug, é preciso executar o comando: `DEBUG=spec:* npm test` (para todos os specs) ou `DEBUG=spec:dados-pessoais npm test` (para um spec específico, que no caso é o de dados-pessoais)