### PR TITLE
refactor: Facilitar horarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "suapi",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1837,9 +1837,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.2.1.tgz",
+      "integrity": "sha512-bTLYHSeC0UH/EFXS9KqWnXuOl/wHK5Z/d+ghd5AsFMYN7wIGkUCOJyzy88+wJKkZPGON8u4Z9f6U4FdgURE9qA==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suapi",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Wrapper para acesso a API do SUAP versão 2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/PeriodosHorarios.ts
+++ b/src/PeriodosHorarios.ts
@@ -1,0 +1,29 @@
+import IPeriodosHorarios from './models/IPeriodosHorarios'
+
+const PERIODOS_HORARIOS: IPeriodosHorarios = {
+    M: [
+        { inicial: [7,0], final: [7,45] },
+        { inicial: [7,45], final: [8,30] },
+        { inicial: [8,50], final: [9,35] },
+        { inicial: [9,35], final: [10,20] },
+        { inicial: [10,30], final: [11,15] },
+        { inicial: [11,15], final: [12,0] }
+    ],
+    V: [
+        { inicial: [13,0], final: [13,45] },
+        { inicial: [13,45], final: [14,30] },
+        { inicial: [14,50], final: [15,35] },
+        { inicial: [15,35], final: [16,20] },
+        { inicial: [16,30], final: [17,15] },
+        { inicial: [17,15], final: [18,0] }
+    ],
+    N: [
+        { inicial: [19,0], final: [19,45] },
+        { inicial: [19,45], final: [20,30] },
+        { inicial: [20,40], final: [21,25] },
+        { inicial: [21,25], final: [22,10] },
+        { inicial: [17,15], final: [18,0] }
+    ]
+}
+
+export default PERIODOS_HORARIOS

--- a/src/SuapiV2.ts
+++ b/src/SuapiV2.ts
@@ -3,10 +3,11 @@ import axios from 'axios'
 import IDadosAlunoV2 from './models/IDadosAlunoV2'
 import ITurmaVirtualLiteV2 from './models/ITurmaVirtualLiteV2'
 import ITurmaVirtualV2 from './models/ITurmaVirtualV2'
-import IPeriodosHorariosV2 from './models/IPeriodosHorariosV2'
 import IHorarioV2 from './models/IHorarioV2'
 import IPeriodoLetivo from './models/IPeriodoLetivo'
 import IBoletim from './models/IBoletim'
+
+import PERIODOS_HORARIOS from './PeriodosHorarios'
 
 export class SuapiV2 {
     public static BASE_URL: string = 'https://suap.ifrn.edu.br/api/v2/'
@@ -15,32 +16,6 @@ export class SuapiV2 {
     public static RESOURCES_TURMA_VIRTUAL_URL: string = 'minhas-informacoes/turma-virtual'
     public static RESOURCES_PERIODOS_LETIVOS_URL: string = 'minhas-informacoes/meus-periodos-letivos'
     public static RESOURCES_BOLETIM_URL: string = 'minhas-informacoes/boletim'
-
-    public static PERIODOS_HORARIOS_V2: IPeriodosHorariosV2 = {
-        M: [
-            '07:00 - 07:45',
-            '07:45 - 08:30',
-            '08:50 - 09:35',
-            '09:35 - 10:20',
-            '10:30 - 11:15',
-            '11:15 - 12:00'
-        ],
-        V: [
-            '13:00 - 13:45',
-            '13:45 - 14:30',
-            '14:40 - 15:25',
-            '15:25 - 16:10',
-            '16:30 - 17:15',
-            '17:15 - 18:00'
-        ],
-        N: [
-            '19:00 - 19:45',
-            '19:45 - 20:30',
-            '20:40 - 21:25',
-            '21:25 - 22:10'
-        ]
-    }
-
 
     /**
      * 
@@ -135,11 +110,13 @@ export class SuapiV2 {
                     const dia = Number(indexes[0])
                     const periodo = indexes[1]
 
+                    let posHorario = 0
                     for (let i = 2; i < indexes.length; i++) {
+                        posHorario = Number(indexes[i]) - 1
                         horarios.push({
                             disciplina: turmaVirtual.descricao,
                             dia,
-                            horario: SuapiV2.PERIODOS_HORARIOS_V2[periodo][i]
+                            horario: PERIODOS_HORARIOS[periodo][posHorario]
                         })
                     }
                 })

--- a/src/models/IPeriodosHorarios.ts
+++ b/src/models/IPeriodosHorarios.ts
@@ -1,0 +1,10 @@
+export interface IHorarioAula {
+    inicial: Array<number>,
+    final: Array<number>
+}
+
+export default interface IPeriodosHorariosV2 {
+    M: Array<IHorarioAula>,
+    V: Array<IHorarioAula>,
+    N: Array<IHorarioAula>
+}

--- a/src/models/IPeriodosHorariosV2.ts
+++ b/src/models/IPeriodosHorariosV2.ts
@@ -1,5 +1,0 @@
-export default interface IPeriodosHorariosV2 {
-    M: Array<string>,
-    V: Array<string>,
-    N: Array<string>
-}


### PR DESCRIPTION
A partir da discussão #14:

- Constante `PERIODOS_HORARIOS` agora é externa a classe `SuapiV2` e possui a seguinte estrutura

```ts
export interface IHorarioAula {
    inicial: Array<number>,
    final: Array<number>
}

export default interface IPeriodosHorariosV2 {
    M: Array<IHorarioAula>,
    V: Array<IHorarioAula>,
    N: Array<IHorarioAula>
}
```
- **Correção de bug do horários**

    Os horários estavam sendo indexados de maneira incorreta. Veja mais em #19 
